### PR TITLE
Fixed memory leaks

### DIFF
--- a/ri3.cpp
+++ b/ri3.cpp
@@ -155,23 +155,17 @@ int match(
 
 	AttributeComparator* nodeComparator;			//to compare node labels
 	AttributeComparator* edgeComparator;			//to compare edge labels
-	AttributeDeconstructor* nodeAttrDeco;			//to free node labels
-	AttributeDeconstructor* edgeAttrDeco;			//to free edge labels
 	switch(filetype){
 		case GFT_GFU:
 		case GFT_GFD:
 			// only nodes have labels and they are strings
 			nodeComparator = new StringAttrComparator();
 			edgeComparator = new DefaultAttrComparator();
-			nodeAttrDeco = new StringAttrDeCo();
-			edgeAttrDeco = new VoidAttrDeCo();
 			takeNodeLabels = true;
 			break;
 		case GFT_GFDA:
 			nodeComparator = new DefaultAttrComparator();
 			edgeComparator = new DefaultAttrComparator();
-			nodeAttrDeco = new StringAttrDeCo();
-			edgeAttrDeco = new VoidAttrDeCo();
 			takeNodeLabels = true;
 			break;
 		case GFT_EGFU:
@@ -179,8 +173,6 @@ int match(
 			//labels on nodes and edges, both of them are strings
 			nodeComparator = new StringAttrComparator();
 			edgeComparator = new StringAttrComparator();
-			nodeAttrDeco = new StringAttrDeCo();
-			edgeAttrDeco = new StringAttrDeCo();
 			takeNodeLabels = true;
 			takeEdgesLabels = true;
 			break;
@@ -188,9 +180,9 @@ int match(
 			//no labels
 			nodeComparator = new DefaultAttrComparator();
 			edgeComparator = new DefaultAttrComparator();
-			nodeAttrDeco = new VoidAttrDeCo();
-			edgeAttrDeco = new VoidAttrDeCo();
 			break;
+    default:
+      return -1;
 	}
 
 	TIMEHANDLE tt_start;
@@ -263,8 +255,8 @@ int match(
 					matchedcouples += tmatchedcouples;
 
 				}
-//				delete rrg;
-				//remember that destroyer are not defined
+        delete rrg;
+				
 			i++;
 		}while(rreaded);
 
@@ -296,9 +288,12 @@ int match(
 //	delete mama;
 //	delete query;
 
-	delete nodeComparator;
-	delete edgeComparator;
-
+  delete mama;
+  delete query;
+  
+  delete nodeComparator;
+  delete edgeComparator;
+  
 	return 0;
 };
 

--- a/rilib/AttributeComparator.h
+++ b/rilib/AttributeComparator.h
@@ -33,8 +33,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #ifndef ATTRIBUTECOMPARATOR_H_
 #define ATTRIBUTECOMPARATOR_H_
 
-#include <string>
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -64,14 +62,14 @@ class StringAttrComparator: public AttributeComparator{
 public:
 	StringAttrComparator(){};
 	virtual bool compare(void* attr1, void* attr2){
-		std::string* a=(std::string*)attr1;
-		std::string* b=(std::string*)attr2;
-		return (a->compare(*b))==0;
+		char* a=(char*)attr1;
+		char* b=(char*)attr2;
+		return (strcmp(a, b))==0;
 	};
 	virtual int compareint(void* attr1, void* attr2){
-		std::string* a=(std::string*)attr1;
-		std::string* b=(std::string*)attr2;
-		return a->compare(*b);
+		char* a=(char*)attr1;
+		char* b=(char*)attr2;
+		return strcmp(a, b);
 	};
 };
 

--- a/rilib/Graph.h
+++ b/rilib/Graph.h
@@ -56,6 +56,24 @@ public:
 		in_adj_list = NULL;
 		out_adj_attrs = NULL;
 	}
+  
+  ~Graph() {
+    int i, j;
+    
+    for (i=0; i<nof_nodes; ++i) {
+      for (j=0; j<out_adj_sizes[i]; ++j) free(out_adj_attrs[i][j]);
+      free(out_adj_attrs[i]);
+      free(in_adj_list[i]);
+      free(out_adj_list[i]);
+      free(nodes_attrs[i]);
+    }
+    free(out_adj_attrs);
+    free(in_adj_list);
+    free(out_adj_list);
+    free(in_adj_sizes);
+    free(out_adj_sizes);
+    free(nodes_attrs);
+  }
 
 
 //	void sort_edges(){

--- a/rilib/Match.h
+++ b/rilib/Match.h
@@ -76,7 +76,8 @@ void match(
 	*steps = solver->steps;
 	*triedcouples = solver->triedcouples;
 	*matchedcouples = solver->matchedcouples;
-
+  
+  delete solver;
 };
 
 }

--- a/rilib/Solver.h
+++ b/rilib/Solver.h
@@ -75,13 +75,13 @@ public:
 	void solve(){
 		int ii;
 
-		int nof_sn 						= mama.nof_sn;
-		void** nodes_attrs 				= mama.nodes_attrs;				//indexed by state_id
-		int* edges_sizes 				= mama.edges_sizes;				//indexed by state_id
-		MaMaEdge** edges 				= mama.edges;					//indexed by state_id
-		int* map_node_to_state 			= mama.map_node_to_state;			//indexed by node_id
-		int* map_state_to_node 			= mama.map_state_to_node;			//indexed by state_id
-		int* parent_state 				= mama.parent_state;			//indexed by state_id
+		int nof_sn 						        = mama.nof_sn;
+		void** nodes_attrs 				    = mama.nodes_attrs;				//indexed by state_id
+		int* edges_sizes 				      = mama.edges_sizes;				//indexed by state_id
+		MaMaEdge** edges 				      = mama.edges;					//indexed by state_id
+		int* map_node_to_state 			  = mama.map_node_to_state;			//indexed by node_id
+		int* map_state_to_node 			  = mama.map_state_to_node;			//indexed by state_id
+		int* parent_state 				    = mama.parent_state;			//indexed by state_id
 		MAMA_PARENTTYPE* parent_type 	= mama.parent_type;				//indexed by state id
 
 
@@ -182,6 +182,15 @@ public:
 				}
 			}
 		}
+    
+    // memory cleanup
+    free(matched);
+    delete[] cmatched;
+    delete[] solution;
+    delete[] candidatesSize;
+    delete[] candidatesIT;
+    delete[] candidates;
+    delete[] listAllRef;
 	}
 
 


### PR DESCRIPTION
I'm looking at using this algorithm to replace the current VF2 based subgraph matching in a code base I'm working on. However, as it stands, this leaks nearly all the memory it allocates during running. I've fixed these leaks by:

Added Graph class deconstructor.
Added matching free/delete calls for memory allocated and used only within functions.
Changed std::string labels to char* labels. No need for the AttributeDeconstructor class now, the Graph deconstructor can handle it correctly.

Now, instead of ballooning out to using ~1GB of memory, my test case sits constantly at less than 1MB total usage.